### PR TITLE
User Settings error

### DIFF
--- a/src/Http/Controllers/Frontend/UserSettingsController.php
+++ b/src/Http/Controllers/Frontend/UserSettingsController.php
@@ -52,7 +52,7 @@ class UserSettingsController extends AuthenticatedController
     public function edit(Request $request)
     {
         $countries = array_map(function ($country) {
-            return $country['name'];
+            return $country->getName();
         }, Loader::countries());
         $twoFactor = $request->user($this->getGuard())->getTwoFactor();
 


### PR DESCRIPTION
Fix for the error

```
Symfony\Component\Debug\Exception\FatalThrowableError: Cannot use object of type Rinvex\Country\Country as array
```

which occours when you try to open the settings page