### PR TITLE
Typo in field sufix

### DIFF
--- a/database/migrations/2016_05_15_133347_create_rinvex_fort_users_table.php
+++ b/database/migrations/2016_05_15_133347_create_rinvex_fort_users_table.php
@@ -42,7 +42,7 @@ class CreateRinvexFortUsersTable extends Migration
             $table->string('first_name')->nullable();
             $table->string('middle_name')->nullable();
             $table->string('last_name')->nullable();
-            $table->string('sufix')->nullable();
+            $table->string('suffix')->nullable();
             $table->string('job_title')->nullable();
             $table->string('country', 2)->nullable();
             $table->text('two_factor')->nullable();

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -61,7 +61,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         'first_name',
         'middle_name',
         'last_name',
-        'sufix',
+        'suffix',
         'job_title',
         'country',
         'birthdate',


### PR DESCRIPTION
In the database the field is/was defined as `sufix` but in the views it's defined as `suffix`.